### PR TITLE
Use `Locale::getDefault()` instead of `setlocale(..., 0)`

### DIFF
--- a/src/LocaleAwareness.php
+++ b/src/LocaleAwareness.php
@@ -4,6 +4,7 @@ namespace gipfl\Format;
 
 use DateTimeZone;
 use IntlTimeZone;
+use Locale;
 use RuntimeException;
 
 trait LocaleAwareness
@@ -55,7 +56,7 @@ trait LocaleAwareness
     protected function getLocale()
     {
         if ($this->locale === null) {
-            $this->locale = setlocale(LC_TIME, 0) ?: 'C';
+            $this->locale = Locale::getDefault();
         }
 
         return $this->locale;


### PR DESCRIPTION
When using `intl` formatters, passing `C`[^C] as the locale is not valid for ICU. This was acceptable until a breaking change in [PHP](https://github.com/php/php-src/issues/12282), which remains broken in PHP 8.1.x. Now, `Locale::getDefault()` is used to ensure valid locales are passed.

fixes Icinga/icingaweb2-module-vspheredb#556

[^C]: If the selected locale in Icinga Web is not installed on the system, `setlocale()` defaults to `C`. A workaround without this patch is to install the locale.